### PR TITLE
ci: add GitHub Actions workflow for nix-darwin build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Build nix-darwin
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - kohei-m4-mac-mini
+          - SC-N-843
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build nix-darwin configuration
+        run: |
+          nix build .#darwinConfigurations.${{ matrix.host }}.system --show-trace
+
+  diff:
+    if: github.event_name == 'pull_request'
+    runs-on: macos-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Diff nix-darwin configurations
+        uses: natsukium/nix-diff-action@main
+        with:
+          attributes: |
+            - displayName: kohei-m4-mac-mini
+              attribute: darwinConfigurations.kohei-m4-mac-mini.system
+            - displayName: SC-N-843
+              attribute: darwinConfigurations.SC-N-843.system

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +33,7 @@ jobs:
   diff:
     if: github.event_name == 'pull_request'
     runs-on: macos-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - "**"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
- Run nix-darwin build on all branch pushes and PRs
- Build both kohei-m4-mac-mini and SC-N-843 configurations
- Use nix-diff-action to comment derivation diff on PRs