### PR TITLE
fix(oberon): restore PATH in hermes-agent systemd service

### DIFF
--- a/hosts/oberon/hermes-agent.nix
+++ b/hosts/oberon/hermes-agent.nix
@@ -29,14 +29,15 @@
 
   # nixosModule が systemd Environment= に MESSAGING_CWD をセットするため、
   # プロセス環境から削除して deprecated 警告を解消する。
+  # environment 全体を lib.mkForce で置換すると、nixosModule が `path`
+  # オプション経由で注入する PATH キー (environment.PATH へ展開される) ごと
+  # 消えてしまい、cat/rm 等の基本コマンドが見つからなくなる。そのため
+  # MESSAGING_CWD キーだけを null 上書きして除外する (null のキーは
+  # systemd unit 生成時に出力されない)。
   # TimeoutStopSec も drain_timeout (180s) + 30s バッファに合わせて延長する。
   systemd.services.hermes-agent = {
     serviceConfig.TimeoutStopSec = lib.mkForce 210;
-    environment = lib.mkForce {
-      HOME = config.services.hermes-agent.stateDir;
-      HERMES_HOME = "${config.services.hermes-agent.stateDir}/.hermes";
-      HERMES_MANAGED = "true";
-    };
+    environment.MESSAGING_CWD = lib.mkForce null;
   };
 
   # hermes gateway は native systemd mode でダッシュボードを自動起動しない。


### PR DESCRIPTION
## 概要

hermes-agent (oberon上) が `cat` / `rm` などのごく一般的なコマンドを実行できず、`write_file` ツールが失敗していた問題を修正する。

## 根本原因

`hosts/oberon/hermes-agent.nix` の `environment = lib.mkForce {...}` が systemd サービスの `environment` attrset を**丸ごと**置換していた。

上流の nixosModule は PATH を `environment.PATH` ではなく **`path` オプション**（内部的に `environment.PATH` へ展開される）で供給している。そのため `mkForce` による全置換が `PATH` キーごと消去し、hermes-agent プロセスの PATH が空になっていた。

```
$ systemctl show hermes-agent --property=Environment
Environment=HERMES_HOME=... HERMES_MANAGED=true HOME=... LOCALE_ARCHIVE=... TZDIR=...
# → PATH が完全に欠落（LOCALE_ARCHIVE/TZDIR は systemd グローバル環境由来で生存）
```

## 修正

`environment` 全体の `mkForce` 置換をやめ、本来の意図だった `MESSAGING_CWD`（deprecated 警告の発生源）の除外だけを **キー単位の `lib.mkForce null`** で実現する。`null` のキーは systemd unit 生成時に出力から除外されるため、警告抑制を維持しつつ PATH と他の環境変数を温存できる。

## 検証

`config.systemd.services.hermes-agent.environment` の eval で確認:

- ✅ `PATH`: `hermes-agent / bash / coreutils / git / findutils / gnugrep / gnused / systemd` の bin が並ぶ（`path` オプション由来が復活）
- ✅ `MESSAGING_CWD`: `null`（unit 出力から除外され deprecated 警告も維持されたまま抑制）
- ✅ `HOME` / `HERMES_HOME` / `HERMES_MANAGED`: 従来通り

## デプロイ

適用には oberon への `nixos-rebuild` が必要。経路系（cloudflared/sshd/network）の変更ではなく hermes-agent サービスの再起動のみなので、通常の `--target-host` デプロイで問題なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)